### PR TITLE
Create windows-safe filenames

### DIFF
--- a/ThunderLixianExporter.js
+++ b/ThunderLixianExporter.js
@@ -45,7 +45,8 @@ TLE.exporter = {
       var aria2 = new ARIA2(TLE.getConfig("TLE_aria2_jsonrpc"));
       $.each(todown.tasklist, function(n, task) {
         $.each(task.filelist, function(l, file) {
-          aria2.addUri(file.downurl, {out: file.title, header: 'Cookie: gdriveid='+todown.gdriveid});
+          filetitle=file.title.replace(/\?/g,' ');
+          aria2.addUri(file.downurl, {out: filetitle, header: 'Cookie: gdriveid='+todown.gdriveid});
         });
       });
       hide_tip();


### PR DESCRIPTION
The issue is, sometimes, exported file name contains question mark which is not allowed in Windows filename, leading to a failed download.
This occurs because xl lixian will just fill in question marks when dealing with unrecognized characters in file names. 

I just propose, think you may have a better approach.
