### PR TITLE
modify thunder website css

### DIFF
--- a/ThunderLixianExporter.js
+++ b/ThunderLixianExporter.js
@@ -372,10 +372,8 @@ TLE.exporter = {
 
           +'.rwbtn.ic_redownloca { display: none !important; }'
           +'.menu { width: 700px !important; }'
-          // thunder css sucks
-          +'.rwbox .w04{width:530px;}'
-          +'.subrwinfo .subw02{width: 620px;}'
-          +'.namelink{width: 523px;}'
+          // for thunder css
+          +'.rwset {width:530px;}'
         +'</style>');
     //pop
     $("body").append('<div id="TLE_text_pop" class="pop_rwbox" style="display: none;margin: 0;"></div>');


### PR DESCRIPTION
Hi,

迅雷离线上网页上按钮会挤成两排，不美观且把'复制链接'给遮挡住了。

简单加了点css修改了下，可能不是最好的解决方案。
